### PR TITLE
Update API URLs from rails-passforge2 to passforge-api service

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -6,7 +6,7 @@
  */
 
 // Base URL for the Rails backend
-export const API_BASE_URL = 'https://rails-passforge2.onrender.com'
+export const API_BASE_URL = 'https://passforge-api.onrender.com'
 
 // API Endpoints
 export const API_ENDPOINTS = {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -39,7 +39,7 @@ export function AuthProvider({ children }) {
 
   const logout = async () => {
     if (token) {
-      await fetch("http://localhost:3000/users/sign_out", {
+      await fetch("https://passforge-api.onrender.com/users/sign_out", {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -9,7 +9,7 @@ export default function Contact() {
   const handleSubmit = async(e)=>{
     e.preventDefault()
     try {
-      const response = await fetch('https://rails-passforge2.onrender.com/contacts',{
+      const response = await fetch('https://passforge-api.onrender.com/contacts',{
         method:'POST',
         headers:{
           "Content-Type": "application/json",

--- a/src/pages/EditProfile.jsx
+++ b/src/pages/EditProfile.jsx
@@ -33,7 +33,7 @@ const EditProfile = () => {
 
     console.log("Token envoyé :", token);
     try {
-      const response = await fetch("https://rails-passforge2.onrender.com/users", {
+      const response = await fetch("https://passforge-api.onrender.com/users", {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -64,7 +64,7 @@ const EditProfile = () => {
     }
 
     try {
-      const response = await fetch("https://rails-passforge2.onrender.com/users", {
+      const response = await fetch("https://passforge-api.onrender.com/users", {
         method: "DELETE",
         headers: {
           "Authorization": `Bearer ${token}`,

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -9,7 +9,7 @@ const ForgotPassword = () => {
     e.preventDefault();
 
     try {
-      const response = await fetch("http://localhost:3000/users/password", {
+      const response = await fetch("https://passforge-api.onrender.com/users/password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ user: { email } }),

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -16,7 +16,7 @@ function Login() {
     setMessage("");
 
     try {
-      const res = await fetch("https://rails-passforge2.onrender.com/users/sign_in", {
+      const res = await fetch("https://passforge-api.onrender.com/users/sign_in", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ user: { email, password } }),

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -12,7 +12,7 @@ const Profile = () => {
     const fetchUserData = async () => {
       try {
          console.log("Token:", token);
-        const res = await fetch("https://rails-passforge2.onrender.com/member-data", {
+        const res = await fetch("https://passforge-api.onrender.com/member-data", {
           headers: {
             "Authorization": `Bearer ${token}`,
             "Content-Type": "application/json"
@@ -44,7 +44,7 @@ const Profile = () => {
     }
 
     try {
-      const response = await fetch("https://rails-passforge2.onrender.com/users", {
+      const response = await fetch("https://passforge-api.onrender.com/users", {
         method: "DELETE",
         headers: {
           "Authorization": `Bearer ${token}`,

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -18,7 +18,7 @@ function Register() {
     setErrors([]);
 
     try {
-      const res = await fetch("https://rails-passforge2.onrender.com/users", {
+      const res = await fetch("https://passforge-api.onrender.com/users", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -15,7 +15,7 @@ const ResetPassword = () => {
     e.preventDefault();
 
     try {
-      const response = await fetch("http://localhost:3000/users/password", {
+      const response = await fetch("https://passforge-api.onrender.com/users/password", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
 **Old URL:** `https://rails-passforge2.onrender.com`
  **New URL:** `https://passforge-api.onrender.com`

  ## Changes

  Updated API endpoints in 9 files:
  - `src/config/api.js` - Central API configuration
  - `src/pages/Login.jsx` - Login endpoint
  - `src/pages/Register.jsx` - Registration endpoint
  - `src/pages/Profile.jsx` - User data fetch and account deletion endpoints
  - `src/pages/EditProfile.jsx` - Profile update and deletion endpoints
  - `src/pages/Contact.jsx` - Contact form endpoint
  - `src/pages/ForgotPassword.jsx` - Password reset request endpoint
  - `src/pages/ResetPassword.jsx` - Password reset endpoint
  - `src/contexts/AuthContext.jsx` - Logout endpoint

  ## Additional fixes

  - Fixed `AuthContext.jsx`, `ForgotPassword.jsx`, and `ResetPassword.jsx` which were
  still using `http://localhost:3000` instead of the production URL